### PR TITLE
Timed campfire destroy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,32 +10,31 @@ plugins {
 repositories {
     mavenCentral()
     maven("https://repo.mineinabyss.com/releases")
-//    maven("https://nexus.okkero.com/repository/maven-releases")
     maven("https://repo.dmulloy2.net/repository/public") // Protocol Lib
+    //maven("https://jitpack.io")
 }
 
 dependencies {
     // Kotlin spice dependencies
     compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json")
-//    compileOnly("com.github.okkero:skedule")
+    compileOnly("com.charleskorn.kaml:kaml")
 
     // Shaded
     implementation("com.mineinabyss:idofront:1.17.1-0.6.22")
+    //implementation("com.github.okkero:skedule")
 
     // Database
-    implementation("org.jetbrains.exposed:exposed-core:$exposedVersion") { isTransitive = false }
-    implementation("org.jetbrains.exposed:exposed-dao:$exposedVersion") { isTransitive = false }
-    implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion") { isTransitive = false }
-    // Sqlite
-    compileOnly("org.xerial:sqlite-jdbc:3.30.1")
+    slim("org.jetbrains.exposed:exposed-core:$exposedVersion") { isTransitive = false }
+    slim("org.jetbrains.exposed:exposed-dao:$exposedVersion") { isTransitive = false }
+    slim("org.jetbrains.exposed:exposed-jdbc:$exposedVersion") { isTransitive = false }
+    slim("org.jetbrains.exposed:exposed-java-time:$exposedVersion") {isTransitive = false }
 
-    //Yaml
-    compileOnly("com.charleskorn.kaml:kaml")
+    // Sqlite
+    slim("org.xerial:sqlite-jdbc:3.30.1")
 
     // Plugin dependencies
     compileOnly ("com.mineinabyss:geary-platform-papermc:0.6.48")
     compileOnly ("com.comphenix.protocol:ProtocolLib:4.7.0")
-
 }
 
 //tasks.shadowJar {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     compileOnly("com.charleskorn.kaml:kaml")
 
     // Shaded
-    implementation("com.mineinabyss:idofront:1.17.1-0.6.22")
+    implementation("com.mineinabyss:idofront:1.17.1-0.6.23")
     implementation("com.github.okkero:Skedule:v1.2.6")
 
     // Database

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
     mavenCentral()
     maven("https://repo.mineinabyss.com/releases")
     maven("https://repo.dmulloy2.net/repository/public") // Protocol Lib
-    //maven("https://jitpack.io")
+    maven("https://jitpack.io")
 }
 
 dependencies {
@@ -21,7 +21,7 @@ dependencies {
 
     // Shaded
     implementation("com.mineinabyss:idofront:1.17.1-0.6.22")
-    //implementation("com.github.okkero:skedule")
+    implementation("com.github.okkero:skedule")
 
     // Database
     slim("org.jetbrains.exposed:exposed-core:$exposedVersion") { isTransitive = false }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 
     // Shaded
     implementation("com.mineinabyss:idofront:1.17.1-0.6.22")
-    implementation("com.github.okkero:skedule")
+    implementation("com.github.okkero:Skedule:v1.2.6")
 
     // Database
     slim("org.jetbrains.exposed:exposed-core:$exposedVersion") { isTransitive = false }

--- a/src/main/java/com/mineinabyss/bonfire/BonfirePlugin.kt
+++ b/src/main/java/com/mineinabyss/bonfire/BonfirePlugin.kt
@@ -1,21 +1,27 @@
 package com.mineinabyss.bonfire
 
-import com.comphenix.protocol.ProtocolLibrary
 import com.mineinabyss.bonfire.config.BonfireConfig
 import com.mineinabyss.bonfire.data.Bonfire
+import com.mineinabyss.bonfire.data.Bonfire.location
+import com.mineinabyss.bonfire.data.Bonfire.stateChangedTimestamp
+import com.mineinabyss.bonfire.data.Bonfire.timeUntilDestroy
+import com.mineinabyss.bonfire.data.Bonfire.uuid
 import com.mineinabyss.bonfire.data.Player
 import com.mineinabyss.bonfire.listeners.BlockListener
 import com.mineinabyss.bonfire.listeners.PlayerListener
-import com.mineinabyss.bonfire.listeners.ChatPacketAdapter
 import com.mineinabyss.geary.minecraft.dsl.attachToGeary
 import com.mineinabyss.idofront.plugin.registerEvents
 import com.mineinabyss.idofront.slimjar.LibraryLoaderInjector
+import com.okkero.skedule.schedule
 import kotlinx.serialization.InternalSerializationApi
 import org.bukkit.Bukkit
+import org.bukkit.Material
 import org.bukkit.NamespacedKey
+import org.bukkit.block.Campfire
 import org.bukkit.plugin.java.JavaPlugin
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.transaction
+import java.time.LocalDateTime
 
 
 val bonfirePlugin: BonfirePlugin by lazy { JavaPlugin.getPlugin(BonfirePlugin::class.java) }
@@ -33,7 +39,7 @@ class BonfirePlugin : JavaPlugin() {
         transaction {
             addLogger(StdOutSqlLogger)
 
-            SchemaUtils.create (Bonfire, Player)
+            SchemaUtils.create(Bonfire, Player)
         }
 
         registerEvents(
@@ -45,6 +51,25 @@ class BonfirePlugin : JavaPlugin() {
 //        protocolManager.addPacketListener(ChatPacketAdapter)
 
         attachToGeary { autoscanComponents() }
+
+        schedule {
+            repeating(BonfireConfig.data.campfireDestroyCheckInterval.inTicks)
+            transaction {
+                Bonfire
+                    .leftJoin(Player, { uuid }, { bonfireUUID })
+                    .select { Player.bonfireUUID.isNull() }
+                    .forEach {
+                        if ((it[stateChangedTimestamp] + it[timeUntilDestroy]) <= LocalDateTime.now()) {
+                            if (it[location].block.state is Campfire) {
+                                it[location].block.type = Material.AIR //FIXME: is this the correct way to destroy a block?
+                                Bukkit.getEntity(it[uuid])?.remove() //FIXME: does the ECS need cleanup?
+
+                                Bonfire.deleteWhere { uuid eq it[uuid] }
+                            }
+                        }
+                    }
+            }
+        }
     }
 
     override fun onDisable() {

--- a/src/main/java/com/mineinabyss/bonfire/BonfirePlugin.kt
+++ b/src/main/java/com/mineinabyss/bonfire/BonfirePlugin.kt
@@ -9,6 +9,7 @@ import com.mineinabyss.bonfire.listeners.PlayerListener
 import com.mineinabyss.bonfire.listeners.ChatPacketAdapter
 import com.mineinabyss.geary.minecraft.dsl.attachToGeary
 import com.mineinabyss.idofront.plugin.registerEvents
+import com.mineinabyss.idofront.slimjar.LibraryLoaderInjector
 import kotlinx.serialization.InternalSerializationApi
 import org.bukkit.Bukkit
 import org.bukkit.NamespacedKey
@@ -26,7 +27,7 @@ class BonfirePlugin : JavaPlugin() {
 
     @InternalSerializationApi
     override fun onEnable() {
-//        LibraryLoaderInjector.inject(this)
+        LibraryLoaderInjector.inject(this)
         saveDefaultConfig()
         BonfireConfig.load()
 

--- a/src/main/java/com/mineinabyss/bonfire/components/BonfireData.kt
+++ b/src/main/java/com/mineinabyss/bonfire/components/BonfireData.kt
@@ -1,6 +1,7 @@
 @file:UseSerializers(UUIDSerializer::class)
 package com.mineinabyss.bonfire.components
 
+import com.mineinabyss.bonfire.data.Bonfire
 import com.mineinabyss.geary.ecs.api.autoscan.AutoscanComponent
 import com.mineinabyss.geary.minecraft.store.encode
 import com.mineinabyss.idofront.items.editItemMeta
@@ -11,6 +12,9 @@ import kotlinx.serialization.UseSerializers
 import org.bukkit.Bukkit
 import org.bukkit.block.Campfire
 import org.bukkit.entity.ArmorStand
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import java.time.LocalDateTime
 import java.util.*
 import org.bukkit.block.data.type.Campfire as BlockDataTypeCampfire
 
@@ -31,6 +35,15 @@ fun BonfireData.updateModel() {
 }
 
 fun BonfireData.save() {
+    if(players.isEmpty()){
+        val bonfireUUID = this.uuid
+        transaction{
+            Bonfire.update({Bonfire.uuid eq bonfireUUID}){
+                it[stateChangedTimestamp] = LocalDateTime.now()
+            }
+        }
+    }
+
     val model = Bukkit.getEntity(this.uuid)
     if (model !is ArmorStand) return
     val block = model.world.getBlockAt(model.location)

--- a/src/main/java/com/mineinabyss/bonfire/config/BonfireConfig.kt
+++ b/src/main/java/com/mineinabyss/bonfire/config/BonfireConfig.kt
@@ -6,13 +6,16 @@ import com.mineinabyss.idofront.config.ReloadScope
 import com.mineinabyss.idofront.recpies.register
 import com.mineinabyss.idofront.serialization.SerializableRecipe
 import com.mineinabyss.idofront.time.TimeSpan
+import com.mineinabyss.idofront.time.days
+import com.mineinabyss.idofront.time.weeks
 import kotlinx.serialization.Serializable
 
 object BonfireConfig : IdofrontConfig<BonfireConfig.Data>(bonfirePlugin, Data.serializer()) {
     @Serializable
     data class Data(
         var bonfireRecipe: SerializableRecipe,
-        var timeUntilcampfireDespawn: TimeSpan,
+        var timeUntilcampfireDespawn: TimeSpan = 1.weeks,
+        var campfireDestroyCheckInterval: TimeSpan = 1.days,
     )
 
     override fun ReloadScope.load() {

--- a/src/main/java/com/mineinabyss/bonfire/config/BonfireConfig.kt
+++ b/src/main/java/com/mineinabyss/bonfire/config/BonfireConfig.kt
@@ -7,13 +7,12 @@ import com.mineinabyss.idofront.recpies.register
 import com.mineinabyss.idofront.serialization.SerializableRecipe
 import com.mineinabyss.idofront.time.TimeSpan
 import kotlinx.serialization.Serializable
-import org.bukkit.Bukkit
 
 object BonfireConfig : IdofrontConfig<BonfireConfig.Data>(bonfirePlugin, Data.serializer()) {
     @Serializable
     data class Data(
         var bonfireRecipe: SerializableRecipe,
-        var campfireDespawnTime: TimeSpan,
+        var timeUntilcampfireDespawn: TimeSpan,
     )
 
     override fun ReloadScope.load() {

--- a/src/main/java/com/mineinabyss/bonfire/config/BonfireConfig.kt
+++ b/src/main/java/com/mineinabyss/bonfire/config/BonfireConfig.kt
@@ -5,6 +5,7 @@ import com.mineinabyss.idofront.config.IdofrontConfig
 import com.mineinabyss.idofront.config.ReloadScope
 import com.mineinabyss.idofront.recpies.register
 import com.mineinabyss.idofront.serialization.SerializableRecipe
+import com.mineinabyss.idofront.time.TimeSpan
 import kotlinx.serialization.Serializable
 import org.bukkit.Bukkit
 
@@ -12,6 +13,7 @@ object BonfireConfig : IdofrontConfig<BonfireConfig.Data>(bonfirePlugin, Data.se
     @Serializable
     data class Data(
         var bonfireRecipe: SerializableRecipe,
+        var campfireDespawnTime: TimeSpan,
     )
 
     override fun ReloadScope.load() {

--- a/src/main/java/com/mineinabyss/bonfire/data/Bonfire.kt
+++ b/src/main/java/com/mineinabyss/bonfire/data/Bonfire.kt
@@ -1,14 +1,22 @@
 package com.mineinabyss.bonfire.data
 
+import com.mineinabyss.bonfire.config.BonfireConfig
+import com.mineinabyss.bonfire.extensions.javaDuration
 import com.mineinabyss.bonfire.extensions.location
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IdTable
 import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.`java-time`.CurrentDateTime
+import org.jetbrains.exposed.sql.`java-time`.datetime
+import org.jetbrains.exposed.sql.`java-time`.duration
 import java.util.*
 
-object Bonfire: IdTable<UUID>() {
+object Bonfire : IdTable<UUID>() {
     val uuid = uuid("uuid").uniqueIndex()
     val location = location("location")
+    val stateChangedTimestamp = datetime("stateChangedTimestamp").defaultExpression(CurrentDateTime())
+    val timeUntilDestroy =
+        duration("timeUntilDestroy").default(BonfireConfig.data.timeUntilcampfireDespawn.javaDuration())
     override val id: Column<EntityID<UUID>>
         get() = uuid.entityId()
 }

--- a/src/main/java/com/mineinabyss/bonfire/data/Bonfire.kt
+++ b/src/main/java/com/mineinabyss/bonfire/data/Bonfire.kt
@@ -6,15 +6,15 @@ import com.mineinabyss.bonfire.extensions.location
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IdTable
 import org.jetbrains.exposed.sql.Column
-import org.jetbrains.exposed.sql.`java-time`.CurrentDateTime
 import org.jetbrains.exposed.sql.`java-time`.datetime
 import org.jetbrains.exposed.sql.`java-time`.duration
+import java.time.LocalDateTime
 import java.util.*
 
 object Bonfire : IdTable<UUID>() {
     val uuid = uuid("uuid").uniqueIndex()
     val location = location("location")
-    val stateChangedTimestamp = datetime("stateChangedTimestamp").defaultExpression(CurrentDateTime())
+    val stateChangedTimestamp = datetime("stateChangedTimestamp").clientDefault { LocalDateTime.now() }
     val timeUntilDestroy =
         duration("timeUntilDestroy").default(BonfireConfig.data.timeUntilcampfireDespawn.javaDuration())
     override val id: Column<EntityID<UUID>>

--- a/src/main/java/com/mineinabyss/bonfire/extensions/Campfire.kt
+++ b/src/main/java/com/mineinabyss/bonfire/extensions/Campfire.kt
@@ -1,15 +1,29 @@
 package com.mineinabyss.bonfire.extensions
 
 import com.mineinabyss.bonfire.components.BonfireData
+import com.mineinabyss.bonfire.data.Bonfire
 import com.mineinabyss.geary.minecraft.store.decode
 import com.mineinabyss.geary.minecraft.store.encode
 import com.mineinabyss.geary.minecraft.store.has
 import org.bukkit.block.Campfire
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.transactions.transaction
 import java.util.*
 
 
 val Campfire.isBonfire: Boolean get() = persistentDataContainer.has<BonfireData>()
 fun Campfire.isBonfire(uuid: UUID): Boolean = bonfireData()?.uuid == uuid
 fun Campfire.bonfireData(): BonfireData? = persistentDataContainer.decode()
-fun Campfire.makeBonfire(uuid: UUID) = persistentDataContainer.encode(BonfireData(uuid))
 fun Campfire.save(data: BonfireData) = persistentDataContainer.encode(data)
+
+fun Campfire.makeBonfire(newBonfireUUID: UUID){
+    val bonfireData = BonfireData(newBonfireUUID)
+    this.save(bonfireData)
+
+    transaction{
+        Bonfire.insert{
+            it[uuid] = newBonfireUUID
+            it[location] = this@makeBonfire.location
+        }
+    }
+}

--- a/src/main/java/com/mineinabyss/bonfire/extensions/Player.kt
+++ b/src/main/java/com/mineinabyss/bonfire/extensions/Player.kt
@@ -18,7 +18,6 @@ import org.jetbrains.exposed.sql.update
 import java.time.Duration
 import java.time.LocalDateTime
 import java.util.*
-import com.mineinabyss.bonfire.data.Player as DataPlayer
 
 fun Player.setRespawnLocation(spawn: RespawnLocation) {
     val oldSpawn = geary(this).get(RespawnLocation::class)
@@ -37,7 +36,6 @@ fun Player.setRespawnLocation(spawn: RespawnLocation) {
 
     val newSpawn = spawn.location.block.state as? Campfire ?: return
     val bonfire = newSpawn.bonfireData() ?: return
-    success("Respawn point set")
 
     if (bonfire.players.size == 0) {
         transaction {
@@ -54,6 +52,8 @@ fun Player.setRespawnLocation(spawn: RespawnLocation) {
                 Bonfire.deleteWhere { Bonfire.uuid eq dbBonfire[Bonfire.uuid] }
 
                 error("The campfire has expired, and degrades to dust")
+
+                return@transaction
             } else {
                 Bonfire.update({ Bonfire.uuid eq bonfire.uuid }) {
                     it[timeUntilDestroy] = newTimeUntilDestroy
@@ -62,17 +62,18 @@ fun Player.setRespawnLocation(spawn: RespawnLocation) {
         }
     }
 
+    success("Respawn point set")
     bonfire.players.add(this.uniqueId)
     bonfire.save()
     geary(this).setPersisting(spawn)
 
-    transaction {
-        val player = DataPlayer.select { DataPlayer.playerUUID eq uniqueId }.single()
-        println(player)
-//        if(player == null) {
-//            val insertData = DataPlayer.insert {  }
-//        }
-    }
+//    transaction {
+//        val player = DataPlayer.select { DataPlayer.playerUUID eq uniqueId }.single()
+//        println(player)
+////        if(player == null) {
+////            val insertData = DataPlayer.insert {  }
+////        }
+//    }
 }
 
 

--- a/src/main/java/com/mineinabyss/bonfire/extensions/Player.kt
+++ b/src/main/java/com/mineinabyss/bonfire/extensions/Player.kt
@@ -3,13 +3,20 @@ package com.mineinabyss.bonfire.extensions
 import com.mineinabyss.bonfire.components.RespawnLocation
 import com.mineinabyss.bonfire.components.save
 import com.mineinabyss.bonfire.components.updateModel
+import com.mineinabyss.bonfire.data.Bonfire
 import com.mineinabyss.geary.minecraft.access.geary
+import com.mineinabyss.idofront.messaging.error
 import com.mineinabyss.idofront.messaging.success
+import org.bukkit.Bukkit
+import org.bukkit.Material
 import org.bukkit.block.Campfire
 import org.bukkit.entity.Player
-import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import java.time.Duration
+import java.time.LocalDateTime
 import java.util.*
 import com.mineinabyss.bonfire.data.Player as DataPlayer
 
@@ -17,9 +24,9 @@ fun Player.setRespawnLocation(spawn: RespawnLocation) {
     val oldSpawn = geary(this).get(RespawnLocation::class)
     if (oldSpawn != null) {
         val block = oldSpawn.location.block.state as? Campfire
-        if(block != null) {
-            if(!block.chunk.isLoaded) block.chunk.load()
-            val bonfire = block.bonfireData();
+        if (block != null) {
+            if (!block.chunk.isLoaded) block.chunk.load()
+            val bonfire = block.bonfireData()
             if (bonfire != null) {
                 bonfire.players.remove(this.uniqueId)
                 bonfire.updateModel()
@@ -29,8 +36,32 @@ fun Player.setRespawnLocation(spawn: RespawnLocation) {
     }
 
     val newSpawn = spawn.location.block.state as? Campfire ?: return
-    val bonfire = newSpawn.bonfireData() ?: return;
+    val bonfire = newSpawn.bonfireData() ?: return
     success("Respawn point set")
+
+    if (bonfire.players.size == 0) {
+        transaction {
+            val dbBonfire = Bonfire.select { Bonfire.uuid eq bonfire.uuid }.first()
+            val newTimeUntilDestroy = Duration.between(
+                LocalDateTime.now(),
+                dbBonfire[Bonfire.stateChangedTimestamp] + dbBonfire[Bonfire.timeUntilDestroy]
+            )
+
+            if (newTimeUntilDestroy.isNegative && dbBonfire[Bonfire.location].block.state is Campfire) {
+                dbBonfire[Bonfire.location].block.type = Material.AIR //FIXME: is this the correct way to destroy a block?
+                Bukkit.getEntity(dbBonfire[Bonfire.uuid])?.remove() //FIXME: does the ECS need cleanup?
+
+                Bonfire.deleteWhere { Bonfire.uuid eq dbBonfire[Bonfire.uuid] }
+
+                error("The campfire has expired, and degrades to dust")
+            } else {
+                Bonfire.update({ Bonfire.uuid eq bonfire.uuid }) {
+                    it[timeUntilDestroy] = newTimeUntilDestroy
+                }
+            }
+        }
+    }
+
     bonfire.players.add(this.uniqueId)
     bonfire.save()
     geary(this).setPersisting(spawn)
@@ -50,7 +81,7 @@ fun Player.removeBonfireSpawnLocation(uuid: UUID): Boolean {
     val respawn = gearyPlayer.get(RespawnLocation::class) ?: return false
     val block = respawn.location.block.state as? Campfire ?: return false
     val bonfire = block.bonfireData() ?: return false
-    if(bonfire.uuid != uuid) return false
+    if (bonfire.uuid != uuid) return false
     success("Respawn point has been removed")
     gearyPlayer.remove(RespawnLocation::class)
     bonfire.players.remove(this.uniqueId)

--- a/src/main/java/com/mineinabyss/bonfire/extensions/TimeSpanConversion.kt
+++ b/src/main/java/com/mineinabyss/bonfire/extensions/TimeSpanConversion.kt
@@ -1,0 +1,7 @@
+package com.mineinabyss.bonfire.extensions
+
+import com.mineinabyss.idofront.time.TimeSpan
+import java.time.Duration
+
+// TODO: Might want to move this function over to TimeSpan in Idofront
+fun TimeSpan.javaDuration(): Duration = Duration.ofMillis(inMillis)

--- a/src/main/java/com/mineinabyss/bonfire/listeners/BlockListener.kt
+++ b/src/main/java/com/mineinabyss/bonfire/listeners/BlockListener.kt
@@ -101,6 +101,8 @@ object BlockListener : Listener {
                 var bonfire = blockState as Campfire
                 bonfire.broadcastVal()
                 bonfire.bonfireData()?.updateModel()
+
+                //if(bonfire.bonfireData().players )
             }
         }
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,3 +14,4 @@ bonfireRecipe:
     custom-model-data: 1
     display-name: §aBonfire
 timeUntilcampfireDespawn: 1m
+campfireDestroyCheckInterval: 10s

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,4 +13,4 @@ bonfireRecipe:
     amount: 1
     custom-model-data: 1
     display-name: §aBonfire
-campfireDespawnTime: 1m
+timeUntilcampfireDespawn: 1m

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,3 +13,4 @@ bonfireRecipe:
     amount: 1
     custom-model-data: 1
     display-name: §aBonfire
+campfireDespawnTime: 1m


### PR DESCRIPTION
Haven't been able to test this code yet, as I'm still struggling to get the plugins running on my papermc server since i came back. This draft is just meant for you to have a look through the code and logic, before I test it. Feel free to ignore it if you rather have me test it before :p

This is my logic described in a pseudocode-y way:

Scenario:
  campfire created at 21:00
  destroy timer is 30 minutes
  currently no players registered with the campfire

  _Row is created in Bonfire table, with `stateChangedTimestamp = 21:00` and `timeUntilDestroy = 30 minutes`_
  
  20 minutes passes
  player comes along and interacts with campfire
  
  _Set `timeUntilDestroy` to `(stateChangedTimestamp + timeUntilDestroy) - Time.now` which is 21:30 - 21:20 = 10 minutes. This only happens if previously there were no registered players with the campfire._
  
  40 minutes passes
  previously registered player sets a new spawn point
  now there are again 0 registered players on our campfire
  
  _set `stateChangedTimestamp` to `Time.now`_

Meanwhile, we have have a periodic task check if `(stateChangedTimestamp + timeUntilDestroy) <= Time.now` for each campfire that has 0 players registered with it
If true, destroy the campfire
This check is also done before the `timeUntilDestroy` value update above, as a player might interact with a campfire after the timer has officially passed but before the periodic tasks checks for it.