### PR TITLE
Use SQLite for data storage instead of PDC

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,32 +10,31 @@ plugins {
 repositories {
     mavenCentral()
     maven("https://repo.mineinabyss.com/releases")
-//    maven("https://nexus.okkero.com/repository/maven-releases")
     maven("https://repo.dmulloy2.net/repository/public") // Protocol Lib
+    //maven("https://jitpack.io")
 }
 
 dependencies {
     // Kotlin spice dependencies
     compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json")
-//    compileOnly("com.github.okkero:skedule")
+    compileOnly("com.charleskorn.kaml:kaml")
 
     // Shaded
     implementation("com.mineinabyss:idofront:1.17.1-0.6.22")
+    //implementation("com.github.okkero:skedule")
 
     // Database
-    implementation("org.jetbrains.exposed:exposed-core:$exposedVersion") { isTransitive = false }
-    implementation("org.jetbrains.exposed:exposed-dao:$exposedVersion") { isTransitive = false }
-    implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion") { isTransitive = false }
-    // Sqlite
-    compileOnly("org.xerial:sqlite-jdbc:3.30.1")
+    slim("org.jetbrains.exposed:exposed-core:$exposedVersion") { isTransitive = false }
+    slim("org.jetbrains.exposed:exposed-dao:$exposedVersion") { isTransitive = false }
+    slim("org.jetbrains.exposed:exposed-jdbc:$exposedVersion") { isTransitive = false }
+    slim("org.jetbrains.exposed:exposed-java-time:$exposedVersion") {isTransitive = false }
 
-    //Yaml
-    compileOnly("com.charleskorn.kaml:kaml")
+    // Sqlite
+    slim("org.xerial:sqlite-jdbc:3.30.1")
 
     // Plugin dependencies
     compileOnly ("com.mineinabyss:geary-platform-papermc:0.6.48")
     compileOnly ("com.comphenix.protocol:ProtocolLib:4.7.0")
-
 }
 
 //tasks.shadowJar {

--- a/src/main/java/com/mineinabyss/bonfire/BonfirePlugin.kt
+++ b/src/main/java/com/mineinabyss/bonfire/BonfirePlugin.kt
@@ -1,12 +1,10 @@
 package com.mineinabyss.bonfire
 
-import com.comphenix.protocol.ProtocolLibrary
 import com.mineinabyss.bonfire.config.BonfireConfig
 import com.mineinabyss.bonfire.data.Bonfire
-import com.mineinabyss.bonfire.data.Player
+import com.mineinabyss.bonfire.data.Players
 import com.mineinabyss.bonfire.listeners.BlockListener
 import com.mineinabyss.bonfire.listeners.PlayerListener
-import com.mineinabyss.bonfire.listeners.ChatPacketAdapter
 import com.mineinabyss.geary.minecraft.dsl.attachToGeary
 import com.mineinabyss.idofront.plugin.registerEvents
 import com.mineinabyss.idofront.slimjar.LibraryLoaderInjector
@@ -14,7 +12,10 @@ import kotlinx.serialization.InternalSerializationApi
 import org.bukkit.Bukkit
 import org.bukkit.NamespacedKey
 import org.bukkit.plugin.java.JavaPlugin
-import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.StdOutSqlLogger
+import org.jetbrains.exposed.sql.addLogger
 import org.jetbrains.exposed.sql.transactions.transaction
 
 
@@ -33,7 +34,7 @@ class BonfirePlugin : JavaPlugin() {
         transaction {
             addLogger(StdOutSqlLogger)
 
-            SchemaUtils.create (Bonfire, Player)
+            SchemaUtils.create(Bonfire, Players)
         }
 
         registerEvents(

--- a/src/main/java/com/mineinabyss/bonfire/BonfirePlugin.kt
+++ b/src/main/java/com/mineinabyss/bonfire/BonfirePlugin.kt
@@ -9,6 +9,7 @@ import com.mineinabyss.bonfire.listeners.PlayerListener
 import com.mineinabyss.bonfire.listeners.ChatPacketAdapter
 import com.mineinabyss.geary.minecraft.dsl.attachToGeary
 import com.mineinabyss.idofront.plugin.registerEvents
+import com.mineinabyss.idofront.slimjar.LibraryLoaderInjector
 import kotlinx.serialization.InternalSerializationApi
 import org.bukkit.Bukkit
 import org.bukkit.NamespacedKey
@@ -26,7 +27,7 @@ class BonfirePlugin : JavaPlugin() {
 
     @InternalSerializationApi
     override fun onEnable() {
-//        LibraryLoaderInjector.inject(this)
+        LibraryLoaderInjector.inject(this)
         saveDefaultConfig()
         BonfireConfig.load()
 

--- a/src/main/java/com/mineinabyss/bonfire/components/BonfireData.kt
+++ b/src/main/java/com/mineinabyss/bonfire/components/BonfireData.kt
@@ -1,6 +1,9 @@
 @file:UseSerializers(UUIDSerializer::class)
+
 package com.mineinabyss.bonfire.components
 
+import com.mineinabyss.bonfire.data.Bonfire
+import com.mineinabyss.bonfire.data.Players
 import com.mineinabyss.geary.ecs.api.autoscan.AutoscanComponent
 import com.mineinabyss.geary.minecraft.store.encode
 import com.mineinabyss.idofront.items.editItemMeta
@@ -11,6 +14,8 @@ import kotlinx.serialization.UseSerializers
 import org.bukkit.Bukkit
 import org.bukkit.block.Campfire
 import org.bukkit.entity.ArmorStand
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.transaction
 import java.util.*
 import org.bukkit.block.data.type.Campfire as BlockDataTypeCampfire
 
@@ -19,15 +24,21 @@ import org.bukkit.block.data.type.Campfire as BlockDataTypeCampfire
 @AutoscanComponent
 class BonfireData(
     val uuid: UUID,
-    val players: MutableSet<UUID> = mutableSetOf()
+    //val players: MutableSet<UUID> = mutableSetOf()
 )
 
 fun BonfireData.updateModel() {
     val model = Bukkit.getEntity(this.uuid)
     if (model !is ArmorStand) return
-    val players = this.players
+    //val players = this.players
     val item = model.equipment?.helmet
-    model.equipment?.helmet = item?.editItemMeta { setCustomModelData(1 + players.size) }
+    //model.equipment?.helmet = item?.editItemMeta { setCustomModelData(1 + players.size) }
+
+    transaction {
+        val playerCount = Players.select { Players.bonfireUUID eq this@updateModel.uuid }.count()
+
+        model.equipment?.helmet = item?.editItemMeta { setCustomModelData(1 + playerCount.toInt()) }
+    }
 }
 
 fun BonfireData.save() {
@@ -38,7 +49,12 @@ fun BonfireData.save() {
     val bonfire = block.state as Campfire
     val bonfireData = block.blockData as BlockDataTypeCampfire
     this.updateModel()
-    bonfireData.isLit = this.players.size > 0
+
+    transaction {
+        val playerCount = Players.select { Players.bonfireUUID eq this@save.uuid }.count()
+        bonfireData.isLit = playerCount > 0
+    }
+
     bonfire.blockData = bonfireData
     bonfire.persistentDataContainer.encode(this)
     bonfire.update()

--- a/src/main/java/com/mineinabyss/bonfire/components/RespawnLocation.kt
+++ b/src/main/java/com/mineinabyss/bonfire/components/RespawnLocation.kt
@@ -1,4 +1,4 @@
-package com.mineinabyss.bonfire.components
+//package com.mineinabyss.bonfire.components
 
 import com.mineinabyss.geary.ecs.api.autoscan.AutoscanComponent
 import com.mineinabyss.idofront.serialization.LocationSerializer
@@ -8,13 +8,13 @@ import kotlinx.serialization.Serializable
 import org.bukkit.Location
 import java.util.*
 
-@Serializable
-@SerialName("bonfire:respawn_location")
-@AutoscanComponent
-class RespawnLocation(
-    @Serializable(with = LocationSerializer::class)
-    val location: Location,
-
-    @Serializable(with = UUIDSerializer::class)
-    val uuid: UUID
-)
+//@Serializable
+//@SerialName("bonfire:respawn_location")
+//@AutoscanComponent
+//class RespawnLocation(
+//    @Serializable(with = LocationSerializer::class)
+//    val location: Location,
+//
+//    //@Serializable(with = UUIDSerializer::class)
+//    //val uuid: UUID
+//)

--- a/src/main/java/com/mineinabyss/bonfire/config/BonfireConfig.kt
+++ b/src/main/java/com/mineinabyss/bonfire/config/BonfireConfig.kt
@@ -5,15 +5,13 @@ import com.mineinabyss.idofront.config.IdofrontConfig
 import com.mineinabyss.idofront.config.ReloadScope
 import com.mineinabyss.idofront.recpies.register
 import com.mineinabyss.idofront.serialization.SerializableRecipe
-import com.mineinabyss.idofront.time.TimeSpan
 import kotlinx.serialization.Serializable
-import org.bukkit.Bukkit
 
 object BonfireConfig : IdofrontConfig<BonfireConfig.Data>(bonfirePlugin, Data.serializer()) {
     @Serializable
     data class Data(
         var bonfireRecipe: SerializableRecipe,
-        var campfireDespawnTime: TimeSpan,
+        var maxPlayerCount: Int = 4,
     )
 
     override fun ReloadScope.load() {

--- a/src/main/java/com/mineinabyss/bonfire/config/BonfireConfig.kt
+++ b/src/main/java/com/mineinabyss/bonfire/config/BonfireConfig.kt
@@ -5,6 +5,7 @@ import com.mineinabyss.idofront.config.IdofrontConfig
 import com.mineinabyss.idofront.config.ReloadScope
 import com.mineinabyss.idofront.recpies.register
 import com.mineinabyss.idofront.serialization.SerializableRecipe
+import com.mineinabyss.idofront.time.TimeSpan
 import kotlinx.serialization.Serializable
 import org.bukkit.Bukkit
 
@@ -12,6 +13,7 @@ object BonfireConfig : IdofrontConfig<BonfireConfig.Data>(bonfirePlugin, Data.se
     @Serializable
     data class Data(
         var bonfireRecipe: SerializableRecipe,
+        var campfireDespawnTime: TimeSpan,
     )
 
     override fun ReloadScope.load() {

--- a/src/main/java/com/mineinabyss/bonfire/data/Bonfire.kt
+++ b/src/main/java/com/mineinabyss/bonfire/data/Bonfire.kt
@@ -6,9 +6,9 @@ import org.jetbrains.exposed.dao.id.IdTable
 import org.jetbrains.exposed.sql.Column
 import java.util.*
 
-object Bonfire: IdTable<UUID>() {
-    val uuid = uuid("uuid").uniqueIndex()
+object Bonfire : IdTable<UUID>() {
+    val entityUUID = uuid("uuid").uniqueIndex()
     val location = location("location")
     override val id: Column<EntityID<UUID>>
-        get() = uuid.entityId()
+        get() = entityUUID.entityId()
 }

--- a/src/main/java/com/mineinabyss/bonfire/data/Players.kt
+++ b/src/main/java/com/mineinabyss/bonfire/data/Players.kt
@@ -2,13 +2,12 @@ package com.mineinabyss.bonfire.data
 
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IdTable
-import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.Column
 import java.util.*
 
-object Player: IdTable<UUID>() {
+object Players : IdTable<UUID>() {
     val playerUUID = uuid("playerUUID").uniqueIndex()
-    var bonfireUUID = uuid("bonfireUUID").references(Bonfire.uuid)
+    var bonfireUUID = uuid("bonfireUUID").references(Bonfire.entityUUID)
     override val id: Column<EntityID<UUID>>
         get() = playerUUID.entityId()
 

--- a/src/main/java/com/mineinabyss/bonfire/extensions/Campfire.kt
+++ b/src/main/java/com/mineinabyss/bonfire/extensions/Campfire.kt
@@ -1,15 +1,29 @@
 package com.mineinabyss.bonfire.extensions
 
 import com.mineinabyss.bonfire.components.BonfireData
+import com.mineinabyss.bonfire.data.Bonfire
 import com.mineinabyss.geary.minecraft.store.decode
 import com.mineinabyss.geary.minecraft.store.encode
 import com.mineinabyss.geary.minecraft.store.has
 import org.bukkit.block.Campfire
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.transactions.transaction
 import java.util.*
 
 
 val Campfire.isBonfire: Boolean get() = persistentDataContainer.has<BonfireData>()
 fun Campfire.isBonfire(uuid: UUID): Boolean = bonfireData()?.uuid == uuid
 fun Campfire.bonfireData(): BonfireData? = persistentDataContainer.decode()
-fun Campfire.makeBonfire(uuid: UUID) = persistentDataContainer.encode(BonfireData(uuid))
 fun Campfire.save(data: BonfireData) = persistentDataContainer.encode(data)
+
+fun Campfire.makeBonfire(uuid: UUID){
+    val bonfireData = BonfireData(uuid)
+    this.save(bonfireData)
+
+    transaction{
+        Bonfire.insert{
+            it[entityUUID] = uuid
+            it[location] = this@makeBonfire.location
+        }
+    }
+}

--- a/src/main/java/com/mineinabyss/bonfire/extensions/Player.kt
+++ b/src/main/java/com/mineinabyss/bonfire/extensions/Player.kt
@@ -1,59 +1,109 @@
 package com.mineinabyss.bonfire.extensions
 
-import com.mineinabyss.bonfire.components.RespawnLocation
 import com.mineinabyss.bonfire.components.save
 import com.mineinabyss.bonfire.components.updateModel
-import com.mineinabyss.geary.minecraft.access.geary
+import com.mineinabyss.bonfire.data.Bonfire
+import com.mineinabyss.bonfire.data.Players
 import com.mineinabyss.idofront.messaging.success
 import org.bukkit.block.Campfire
 import org.bukkit.entity.Player
-import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.util.*
-import com.mineinabyss.bonfire.data.Player as DataPlayer
 
-fun Player.setRespawnLocation(spawn: RespawnLocation) {
-    val oldSpawn = geary(this).get(RespawnLocation::class)
-    if (oldSpawn != null) {
-        val block = oldSpawn.location.block.state as? Campfire
-        if(block != null) {
-            if(!block.chunk.isLoaded) block.chunk.load()
-            val bonfire = block.bonfireData();
-            if (bonfire != null) {
-                bonfire.players.remove(this.uniqueId)
-                bonfire.updateModel()
-                bonfire.save()
+fun Player.setRespawnLocation(bonfireUUID: UUID) {
+    val playerUUID = uniqueId
+
+    transaction {
+        val playerRow = Players
+            .select { Players.playerUUID eq playerUUID }
+            .firstOrNull()
+
+        if (playerRow != null && playerRow[Players.bonfireUUID] != bonfireUUID) {
+            val oldBonfireBlock = Bonfire
+                .select { Players.bonfireUUID eq playerRow[Players.bonfireUUID] }
+                .first()[Bonfire.location]
+                .block.state as? Campfire ?: return@transaction
+
+            if (!oldBonfireBlock.chunk.isLoaded) oldBonfireBlock.chunk.load()
+
+            Players.update({ Players.playerUUID eq playerRow[Players.playerUUID] }) {
+                it[Players.bonfireUUID] = bonfireUUID
             }
+
+            val oldBonfire = oldBonfireBlock.bonfireData()
+            if (oldBonfire != null) {
+                oldBonfire.updateModel()
+                oldBonfire.save()
+            }
+        } else if (playerRow == null) {
+            Players.insert {
+                it[Players.playerUUID] = playerUUID
+                it[Players.bonfireUUID] = bonfireUUID
+            }
+            val newBonfire = Bonfire
+                .select { Bonfire.entityUUID eq bonfireUUID }
+                .first()[Bonfire.location]
+                .block.state as? Campfire ?: return@transaction
+            newBonfire.bonfireData()?.save() ?: return@transaction
         }
     }
 
-    val newSpawn = spawn.location.block.state as? Campfire ?: return
-    val bonfire = newSpawn.bonfireData() ?: return;
-    success("Respawn point set")
-    bonfire.players.add(this.uniqueId)
-    bonfire.save()
-    geary(this).setPersisting(spawn)
 
-    transaction {
-        val player = DataPlayer.select { DataPlayer.playerUUID eq uniqueId }.single()
-        println(player)
-//        if(player == null) {
-//            val insertData = DataPlayer.insert {  }
+//    val oldSpawn = geary(this).get(RespawnLocation::class)
+//    if (oldSpawn != null) {
+//        val block = oldSpawn.location.block.state as? Campfire
+//        if(block != null) {
+//            if(!block.chunk.isLoaded) block.chunk.load()
+//            val bonfire = block.bonfireData();
+//            if (bonfire != null) {
+//                bonfire.players.remove(this.uniqueId)
+//                bonfire.updateModel()
+//                bonfire.save()
+//            }
 //        }
-    }
+//    }
+//
+//    val newSpawn = spawn.location.block.state as? Campfire ?: return
+//    val bonfire = newSpawn.bonfireData() ?: return;
+//    success("Respawn point set")
+//    bonfire.players.add(this.uniqueId)
+//    bonfire.save()
+//    geary(this).setPersisting(spawn)
+//
+//    transaction {
+//        val player = DataPlayer.select { DataPlayer.playerUUID eq uniqueId }.single()
+//        println(player)
+////        if(player == null) {
+////            val insertData = DataPlayer.insert {  }
+////        }
+//    }
 }
 
 
-fun Player.removeBonfireSpawnLocation(uuid: UUID): Boolean {
-    val gearyPlayer = geary(this)
-    val respawn = gearyPlayer.get(RespawnLocation::class) ?: return false
-    val block = respawn.location.block.state as? Campfire ?: return false
-    val bonfire = block.bonfireData() ?: return false
-    if(bonfire.uuid != uuid) return false
-    success("Respawn point has been removed")
-    gearyPlayer.remove(RespawnLocation::class)
-    bonfire.players.remove(this.uniqueId)
-    bonfire.save()
+fun Player.removeBonfireSpawnLocation(bonfireUUID: UUID): Boolean {
+    val playerUUID = uniqueId
+    transaction {
+        val deleteReturnCode = Players
+            .deleteWhere(limit = 1) {
+                (Players.playerUUID eq playerUUID) and (Players.bonfireUUID eq bonfireUUID)
+            }
+        if (deleteReturnCode == 0) return@transaction false
+        success("Respawn point has been removed")
+        val bonfire =
+            Bonfire.select { Bonfire.entityUUID eq bonfireUUID }.first()[Bonfire.location].block.state as? Campfire
+                ?: return@transaction false
+        bonfire.bonfireData()?.save() ?: return@transaction false
+    }
     return true
+//    val gearyPlayer = geary(this)
+//    val respawn = gearyPlayer.get(RespawnLocation::class) ?: return false
+//    val block = respawn.location.block.state as? Campfire ?: return false
+//    val bonfire = block.bonfireData() ?: return false
+//    if(bonfire.uuid != uuid) return false
+//    success("Respawn point has been removed")
+//    gearyPlayer.remove(RespawnLocation::class)
+//    bonfire.players.remove(this.uniqueId)
+//    bonfire.save()
+//    return true
 }

--- a/src/main/java/com/mineinabyss/bonfire/listeners/BlockListener.kt
+++ b/src/main/java/com/mineinabyss/bonfire/listeners/BlockListener.kt
@@ -101,6 +101,8 @@ object BlockListener : Listener {
                 var bonfire = blockState as Campfire
                 bonfire.broadcastVal()
                 bonfire.bonfireData()?.updateModel()
+
+                //if(bonfire.bonfireData().players )
             }
         }
     }

--- a/src/main/java/com/mineinabyss/bonfire/listeners/PacketListener.kt
+++ b/src/main/java/com/mineinabyss/bonfire/listeners/PacketListener.kt
@@ -5,7 +5,6 @@ import com.comphenix.protocol.events.ListenerPriority
 import com.comphenix.protocol.events.PacketAdapter
 import com.comphenix.protocol.events.PacketEvent
 import com.mineinabyss.bonfire.bonfirePlugin
-import com.mineinabyss.bonfire.components.RespawnLocation
 import com.mineinabyss.geary.minecraft.access.geary
 import com.mineinabyss.idofront.messaging.broadcastVal
 

--- a/src/main/java/com/mineinabyss/bonfire/listeners/PlayerListener.kt
+++ b/src/main/java/com/mineinabyss/bonfire/listeners/PlayerListener.kt
@@ -1,13 +1,13 @@
 package com.mineinabyss.bonfire.listeners
 
-import com.mineinabyss.bonfire.components.RespawnLocation
-import com.mineinabyss.bonfire.components.save
+import com.mineinabyss.bonfire.config.BonfireConfig
+import com.mineinabyss.bonfire.data.Bonfire
+import com.mineinabyss.bonfire.data.Players
 import com.mineinabyss.bonfire.extensions.*
-import com.mineinabyss.geary.minecraft.access.geary
 import com.mineinabyss.idofront.entities.leftClicked
-import com.mineinabyss.idofront.entities.rightClicked
 import com.mineinabyss.idofront.messaging.*
 import org.bukkit.Material
+import org.bukkit.block.Campfire
 import org.bukkit.block.data.type.Bed
 import org.bukkit.entity.ArmorStand
 import org.bukkit.entity.EntityType
@@ -16,12 +16,10 @@ import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.entity.EntityDamageEvent
 import org.bukkit.event.entity.EntityDeathEvent
-import org.bukkit.event.player.PlayerArmorStandManipulateEvent
-import org.bukkit.event.player.PlayerBedEnterEvent
-import org.bukkit.event.player.PlayerInteractEvent
-import org.bukkit.event.player.PlayerRespawnEvent
+import org.bukkit.event.player.*
 import org.bukkit.inventory.EquipmentSlot
-import org.bukkit.block.Campfire as BlockCampfire
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.transaction
 
 object PlayerListener : Listener {
 
@@ -38,9 +36,9 @@ object PlayerListener : Listener {
     @EventHandler
     fun PlayerInteractEvent.rightClickCampfire() {
         val clicked = clickedBlock ?: return // If no block was clicked, return
-        if (hand == EquipmentSlot.OFF_HAND) return;
+        if (hand == EquipmentSlot.OFF_HAND) return
         if (clicked.type == Material.CAMPFIRE) {
-            val respawnCampfire = clicked.state as BlockCampfire
+            val respawnCampfire = clicked.state as Campfire
             val bonfire = respawnCampfire.bonfireData() ?: return
 
             if (leftClicked) {
@@ -50,50 +48,74 @@ object PlayerListener : Listener {
                 return
             }
 
-            if(bonfire.players.size >= 4) {
-                return player.error("This campfire is full!")
+            transaction {
+                val playerCount = Players.select { Players.bonfireUUID eq bonfire.uuid }.count()
+                if (playerCount >= BonfireConfig.data.maxPlayerCount) {
+                    return@transaction player.error("This campfire is full!")
+                }
             }
 
-            player.setRespawnLocation(RespawnLocation(clicked.location, bonfire.uuid))
-        } else
-        if (clicked.blockData is Bed) {
+            player.setRespawnLocation(bonfire.uuid)
+        } else if (clicked.blockData is Bed) {
             isCancelled = true
         }
     }
 
     @EventHandler
     fun EntityDamageEvent.event() {
-        if(!(entity is Player && cause == EntityDamageEvent.DamageCause.FIRE)) return
+        if (!(entity is Player && cause == EntityDamageEvent.DamageCause.FIRE)) return
         val player = entity as Player
-        if(player.world.getBlockAt(player.location).state is BlockCampfire) isCancelled = true
+        if (player.world.getBlockAt(player.location).state is Campfire) isCancelled = true
     }
 
     @EventHandler
     fun PlayerRespawnEvent.event() {
-        val gearyPlayer = geary(player)
-        val respawnLocation = gearyPlayer.get<RespawnLocation>() ?: return
-        respawnLocation.broadcastVal()
-        val respawnBlock = player.world.getBlockAt(respawnLocation.location)
-        respawnBlock.type.broadcastVal()
-        if(respawnBlock.state is BlockCampfire) {
-            val campfire = respawnBlock.state as BlockCampfire
-            campfire.bonfireData()?.uuid.broadcastVal("Bonfire UUID")
-            respawnLocation.uuid.broadcastVal("Respawn UUID")
-            if (campfire.isBonfire(respawnLocation.uuid)) {
-                player.info("Respawning at bonfire")
-                setRespawnLocation(respawnLocation.location.toCenterLocation())
-                return
+        val playerUUID = player.uniqueId
+        transaction {
+            val respawnBonfire = (Players innerJoin Bonfire)
+                .select { Players.playerUUID eq playerUUID }
+                .firstOrNull() ?: return@transaction
+            val respawnBonfireLocation = respawnBonfire[Bonfire.location]
+            respawnBonfireLocation.broadcastVal()
+            val respawnBlock = player.world.getBlockAt(respawnBonfireLocation)
+            respawnBlock.broadcastVal()
+            if (respawnBlock.state is Campfire) {
+                val campfire = respawnBlock.state as Campfire
+                campfire.bonfireData()?.uuid.broadcastVal("Bonfire UUID")
+                if (campfire.isBonfire(respawnBonfire[Bonfire.entityUUID])) {
+                    player.info("Respawning at bonfire")
+                    respawnLocation = respawnBonfireLocation.toCenterLocation()
+                    return@transaction
+                }
             }
+
+            //TODO: Handle if there is no bonfire at the location (remove from Bonfire table and remove player entry)
         }
 
-        logVal("Bonfire missing for player " + player.name)
-        player.error("Bonfire not found")
-        gearyPlayer.remove(RespawnLocation::class)
+//        val gearyPlayer = geary(player)
+//        val respawnLocation = gearyPlayer.get<RespawnLocation>() ?: return
+//        respawnLocation.broadcastVal()
+//        val respawnBlock = player.world.getBlockAt(respawnLocation.location)
+//        respawnBlock.type.broadcastVal()
+//        if (respawnBlock.state is Campfire) {
+//            val campfire = respawnBlock.state as Campfire
+//            campfire.bonfireData()?.uuid.broadcastVal("Bonfire UUID")
+//            respawnLocation.uuid.broadcastVal("Respawn UUID")
+//            if (campfire.isBonfire(respawnLocation.uuid)) {
+//                player.info("Respawning at bonfire")
+//                setRespawnLocation(respawnLocation.location.toCenterLocation())
+//                return
+//            }
+//        }
+//
+//        logVal("Bonfire missing for player " + player.name)
+//        player.error("Bonfire not found")
+//        gearyPlayer.remove(RespawnLocation::class)
     }
 
     @EventHandler
     fun PlayerArmorStandManipulateEvent.event() {
-        if(rightClicked.isBonfireModel()) isCancelled = true
+        if (rightClicked.isBonfireModel()) isCancelled = true
     }
 
     @EventHandler

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,4 +13,4 @@ bonfireRecipe:
     amount: 1
     custom-model-data: 1
     display-name: §aBonfire
-campfireDespawnTime: 1m
+maxPlayerCount: 4

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,3 +13,4 @@ bonfireRecipe:
     amount: 1
     custom-model-data: 1
     display-name: §aBonfire
+campfireDespawnTime: 1m


### PR DESCRIPTION
I've also rewritten parts of the code to move away from storing data in ECS components, and instead query data from the SQL database. I wasn't sure if you made any progress on this so I kept it as a separate branch from the timed destroy stuff. Just like the other PR, haven't been able to test it yet. Don't merge yet!

I also opted to completely get rid of the RespawnLocation ECS component as all the data is stored in the DB, but maybe we want to keep some respawn data on the player character? idk. In this version the only ECS component that's left is BonfireData, and it only stores the armorstand uuid, which is also stored in the DB. Do we really need ECS components if we opt to store data in the DB for this plugin? Tagging @0ffz as well